### PR TITLE
Add CLI support

### DIFF
--- a/packages/balrun/bin/cli.mjs
+++ b/packages/balrun/bin/cli.mjs
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+
+import { Ballerina } from "../dist/index.mjs";
+
+const path = process.argv[2];
+
+if (!path) {
+	process.stderr.write(
+		"usage: balrun [<source-file.bal> | <package-dir> | .]\n",
+	);
+	process.exit(1);
+}
+
+const result = await new Ballerina().run(path);
+
+if (result) {
+	process.stderr.write(`error: ${result.error}\n`);
+	process.exit(1);
+}

--- a/packages/balrun/package.json
+++ b/packages/balrun/package.json
@@ -13,8 +13,12 @@
 		}
 	},
 	"files": [
+		"bin",
 		"dist"
 	],
+	"bin": {
+		"balrun": "./bin/cli.mjs"
+	},
 	"scripts": {
 		"build": "tsdown && cp ../ballerina-wasm/dist/ballerina.wasm dist/ballerina.wasm",
 		"clean": "git clean -xdf .turbo dist"

--- a/packages/balrun/package.json
+++ b/packages/balrun/package.json
@@ -1,6 +1,21 @@
 {
 	"name": "@snelusha/balrun",
 	"version": "0.1.0",
+	"description": "Run Ballerina anywhere!",
+	"license": "MIT",
+	"author": {
+		"name": "Sithija Nelusha Silva",
+		"email": "hello@snelusha.dev",
+		"url": "https://snelusha.dev"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/snelusha/balrun.git",
+		"directory": "packages/balrun"
+	},
+	"bugs": {
+		"url": "https://github.com/snelusha/balrun/issues"
+	},
 	"type": "module",
 	"main": "./dist/index.mjs",
 	"module": "./dist/index.mjs",


### PR DESCRIPTION
This pull request updates the `package.json` for the `@snelusha/balrun` package to add important project metadata and configure the CLI entry point. These changes help make the package more discoverable, properly attributed, and ready for distribution as a command-line tool.

**Metadata and distribution improvements:**

* Added project description, license, author information, repository details, and bug tracking URL to `package.json` to improve discoverability and attribution.

**CLI and packaging configuration:**

* Added the `bin` field to expose `balrun` as a CLI command and included the `bin` directory in the published files.