### PR TITLE
Refactor FS interface and add examples

### DIFF
--- a/packages/balrun/README.md
+++ b/packages/balrun/README.md
@@ -25,28 +25,23 @@ const ballerina = new Ballerina();
 const result = await ballerina.run("./main.bal");
 ```
 
-By default, `Ballerina` uses `NodeFS` to read files from disk. You can swap this out with any custom filesystem by implementing the `FS` interface and passing it in.
-
 ### Custom `FS`
+
+By default, `Ballerina` uses `NodeFS` to read files from disk. You can swap this out with any custom filesystem by implementing the `FS` interface and passing it in.
 
 ```ts
 import { Ballerina, type FS } from "@snelusha/balrun";
 
 class MemFS implements FS {
-  private data = new Map<string, string>([
-    ["main.bal", `import ballerina/io;\npublic function main() { io:println("hello"); }`],
-  ]);
-
-  open(path: string) {
-    const text = this.data.get(path);
-    return text == null ? null : { content: text, size: text.length, modTime: 0, isDir: false };
-  }
-
-  // implement remaining FS methods
+	// When running a single file, only `open` and `stat` are required.
+	// When running a package, `readDir` is also required.
 }
 
-const result = await new Ballerina({ fs: new MemFS() }).run("main.bal");
+const fs = new MemFS({ "main.bal": `...` });
+await new Ballerina({ fs }).run("main.bal");
 ```
+
+See [`examples/mem-fs`](https://github.com/snelusha/balrun/tree/main/packages/balrun/examples/mem-fs) for a full `MemFS` implementation.
 
 ## Acknowledgements
 

--- a/packages/balrun/examples/mem-fs/bun.lock
+++ b/packages/balrun/examples/mem-fs/bun.lock
@@ -1,0 +1,31 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "mem-fs",
+      "dependencies": {
+        "@snelusha/balrun": "^0.1.0",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+      },
+      "peerDependencies": {
+        "typescript": "^6.0.2",
+      },
+    },
+  },
+  "packages": {
+    "@snelusha/balrun": ["@snelusha/balrun@0.1.0", "", { "bin": { "balrun": "bin/cli.mjs" } }, "sha512-nMW/0G+v/JXj5XiFz3kIpz11emuwJRnOPGdm0GPhtkOMvTMnXWbndCaaiO+yPW30WUDdIrgf6pnKePKDGI8zLQ=="],
+
+    "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+
+    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+
+    "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
+
+    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+  }
+}

--- a/packages/balrun/examples/mem-fs/index.ts
+++ b/packages/balrun/examples/mem-fs/index.ts
@@ -1,0 +1,59 @@
+import { Ballerina, type FS } from "@snelusha/balrun";
+
+// When running a single file, only `open` and `stat` are required.
+// When running a package, `readDir` is also required.
+class MemFS implements FS {
+	private files = new Map<string, string>();
+
+	constructor(files: Record<string, string>) {
+		for (const [path, content] of Object.entries(files)) {
+			this.files.set(path, content);
+		}
+	}
+
+	open(path: string) {
+		const content = this.files.get(path);
+		return content == null
+			? null
+			: { content, size: content.length, modTime: 0, isDir: false };
+	}
+
+	stat(path: string) {
+		if (path === ".") {
+			return { name: ".", size: 0, modTime: 0, isDir: true };
+		}
+		const content = this.files.get(path);
+		return content == null
+			? null
+			: { name: path, size: content.length, modTime: 0, isDir: false };
+	}
+
+	readDir(path: string) {
+		if (path === ".") {
+			return Array.from(this.files.keys()).map((name) => ({
+				name,
+				isDir: false,
+			}));
+		}
+		return null;
+	}
+
+	writeFile(): boolean {
+		throw new Error("Method not implemented.");
+	}
+	remove(): boolean {
+		throw new Error("Method not implemented.");
+	}
+	move(): boolean {
+		throw new Error("Method not implemented.");
+	}
+	mkdirAll(): boolean {
+		throw new Error("Method not implemented.");
+	}
+}
+
+const fs = new MemFS({
+	"main.bal": `import ballerina/io;\npublic function main() { io:println("Hello, World!"); }`,
+});
+
+await new Ballerina({ fs }).run("main.bal");

--- a/packages/balrun/examples/mem-fs/package.json
+++ b/packages/balrun/examples/mem-fs/package.json
@@ -1,0 +1,15 @@
+{
+	"name": "mem-fs",
+	"module": "index.ts",
+	"type": "module",
+	"private": true,
+	"devDependencies": {
+		"@types/bun": "latest"
+	},
+	"peerDependencies": {
+		"typescript": "^6.0.2"
+	},
+	"dependencies": {
+		"@snelusha/balrun": "^0.1.0"
+	}
+}

--- a/packages/balrun/src/fs.ts
+++ b/packages/balrun/src/fs.ts
@@ -1,17 +1,23 @@
+export type OpenResult = {
+	content: string;
+	size: number;
+	modTime: number;
+	isDir: boolean;
+} | null;
+
+export type StatResult = {
+	name: string;
+	size: number;
+	modTime: number;
+	isDir: boolean;
+} | null;
+
+export type ReadDirResult = { name: string; isDir: boolean }[] | null;
+
 export interface FS {
-	open(path: string): {
-		content: string;
-		size: number;
-		modTime: number;
-		isDir: boolean;
-	} | null;
-	stat(path: string): {
-		name: string;
-		size: number;
-		modTime: number;
-		isDir: boolean;
-	} | null;
-	readDir(path: string): { name: string; isDir: boolean }[] | null;
+	open(path: string): OpenResult;
+	stat(path: string): StatResult;
+	readDir(path: string): ReadDirResult;
 	writeFile(path: string, content: string): boolean;
 	remove(path: string): boolean;
 	move(oldPath: string, newPath: string): boolean;


### PR DESCRIPTION
This pull request introduces a new example for using a custom in-memory filesystem (`MemFS`) with the Ballerina runner, clarifies documentation on custom filesystems, and refactors the `FS` interface for improved type safety. The most important changes are as follows:

**New Example and Documentation Improvements**
* Added a complete `MemFS` implementation example in `packages/balrun/examples/mem-fs/index.ts` and referenced it in the documentation to help users understand how to use a custom filesystem with the Ballerina runner. [[1]](diffhunk://#diff-3a7651410dea9503709d98c09ab02f0a2cf2b15a153c29efefce32a34ea4e564R1-R59) [[2]](diffhunk://#diff-6027733821cc8feff24c9f230a182fc2084d2633dfe2769bfd17455816ed02caL28-R45)
* Updated the `README.md` to clarify which methods must be implemented for different use cases (single file vs. package) and to reference the new example.

**Type Safety and Interface Refactor**
* Refactored the `FS` interface in `packages/balrun/src/fs.ts` to introduce distinct types (`OpenResult`, `StatResult`, `ReadDirResult`) for method return values, improving type safety and code clarity.

**Project Structure**
* Added a `package.json` for the new `mem-fs` example, specifying dependencies and configuration.