### PR TITLE
Rename `wasmUrl` to `wasmSource` for clarity

### DIFF
--- a/packages/balrun/README.md
+++ b/packages/balrun/README.md
@@ -106,14 +106,12 @@ await new Ballerina({ fs: new NodeFS() }).run("./main.bal");
 
 See [`examples/memfs`](https://github.com/snelusha/balrun/tree/main/examples/memfs) for a full implementation.
 
-### `wasmUrl` / `core`
+### `wasmSource` / `core`
 
-By default, `Ballerina` loads the bundled `ballerina.wasm`. Pass `wasmUrl` to load a different local path or HTTP(S) URL:
+By default, `Ballerina` loads the bundled `ballerina.wasm`. Pass `wasmSource` to load a different local path or HTTP(S) URL:
 
 ```ts
-await new Ballerina({ wasmUrl: "https://example.com/ballerina.wasm" }).run(
-  "main.bal",
-);
+await new Ballerina({ wasmSource: "https://example.com/ballerina.wasm" }).run("main.bal");
 ```
 
 For custom loading, pass a `BallerinaCore` directly. `WasmBridge.load()` accepts a local path, URL, `Response`, or `Promise<Response>`:

--- a/packages/balrun/src/ballerina.ts
+++ b/packages/balrun/src/ballerina.ts
@@ -12,17 +12,17 @@ export interface BallerinaOptions extends BallerinaRunOptions {
 	/** Filesystem exposed to the Ballerina runtime. Defaults to the Node adapter in Node.js. Required in browsers. */
 	fs?: FS;
 	/**
-	 * A pre-constructed Ballerina core. When provided, `wasmUrl` is ignored and
+	 * A pre-constructed Ballerina core. When provided, `wasmSource` is ignored and
 	 * this core is used directly instead of loading the bundled WASM binary.
 	 */
 	core?: BallerinaCore;
 	/** URL or local path of the Ballerina WASM binary to load. */
-	wasmUrl?: string;
+	wasmSource?: string;
 }
 
 export class Ballerina {
 	private _coreOption: BallerinaCore | undefined;
-	private _wasmUrl: string | undefined;
+	private _wasmSource: string | undefined;
 	private _bridge: BallerinaCore | null = null;
 	private _bridgePromise: Promise<BallerinaCore> | null = null;
 
@@ -32,7 +32,7 @@ export class Ballerina {
 	constructor(options: BallerinaOptions = {}) {
 		this._fs = options.fs;
 		this._coreOption = options.core;
-		this._wasmUrl = options.wasmUrl;
+		this._wasmSource = options.wasmSource;
 
 		this._defaults = {
 			colors: options.colors ?? true,
@@ -55,7 +55,7 @@ export class Ballerina {
 				const bridge = this._coreOption
 					? this._coreOption
 					: await import("./wasm-bridge").then(({ WasmBridge }) =>
-							WasmBridge.load(this._wasmUrl ?? DEFAULT_WASM_PATH),
+							WasmBridge.load(this._wasmSource ?? DEFAULT_WASM_PATH),
 						);
 
 				this._bridge = bridge;

--- a/packages/balrun/src/react.ts
+++ b/packages/balrun/src/react.ts
@@ -11,11 +11,11 @@ export function useBallerina(options: BallerinaOptions = {}) {
 	const [isReady, setIsReady] = useState(false);
 	const [error, setError] = useState<Error | null>(null);
 
-	const { fs, core, wasmUrl, colors, stdout, stderr } = options;
+	const { fs, core, wasmSource, colors, stdout, stderr } = options;
 
 	const opts = useMemo(
-		() => ({ fs, core, wasmUrl, colors, stdout, stderr }),
-		[fs, core, wasmUrl, colors, stdout, stderr],
+		() => ({ fs, core, wasmSource, colors, stdout, stderr }),
+		[fs, core, wasmSource, colors, stdout, stderr],
 	);
 
 	useEffect(() => {

--- a/packages/balrun/tests/ballerina.test.ts
+++ b/packages/balrun/tests/ballerina.test.ts
@@ -80,7 +80,7 @@ describe("Ballerina", () => {
 	it("allows retrying initialization after a bridge load failure", async () => {
 		const ballerina = new Ballerina({
 			fs: new MemFS({ "main.bal": "" }),
-			wasmUrl: "https://localhost:6969/missing.wasm",
+			wasmSource: "https://localhost:6969/missing.wasm",
 		});
 
 		expect(ballerina.run("main.bal")).rejects.toThrow(


### PR DESCRIPTION
Resolves #28 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README and documentation examples to reflect the current API configuration options.

* **Refactor**
  * Renamed the WASM configuration option from `wasmUrl` to `wasmSource`. The change applies to all public interfaces and hooks within the API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->