### PR TITLE
Prefix balrun errors

### DIFF
--- a/packages/balrun/src/ballerina.ts
+++ b/packages/balrun/src/ballerina.ts
@@ -64,7 +64,7 @@ export class Ballerina {
 			} catch (err) {
 				this._bridgePromise = null;
 				throw new Error(
-					`Ballerina: Failed to initialize the WASM bridge: ${err instanceof Error ? err.message : err}`,
+					`[balrun]: failed to initialize the WASM bridge: ${err instanceof Error ? err.message : err}`,
 				);
 			}
 		})();
@@ -76,7 +76,7 @@ export class Ballerina {
 		if (this._fs) return this._fs;
 		if (!supportsNodeFS())
 			throw new Error(
-				"Ballerina requires an `fs` option outside Node-compatible environments.",
+				"[balrun]: `fs` option is required outside Node-compatible environments.",
 			);
 
 		const fs = new NodeFS();

--- a/packages/balrun/src/react.ts
+++ b/packages/balrun/src/react.ts
@@ -32,7 +32,9 @@ export function useBallerina(options: BallerinaOptions = {}) {
 			.catch(
 				(err) =>
 					!cancelled &&
-					setError(err instanceof Error ? err : new Error(String(err))),
+					setError(
+						err instanceof Error ? err : new Error(`[balrun]: ${String(err)}`),
+					),
 			);
 
 		return () => {
@@ -47,7 +49,9 @@ export function useBallerina(options: BallerinaOptions = {}) {
 			options?: BallerinaRunOptions,
 		): Promise<BallerinaRunResult> => {
 			if (!ballerinaRef.current || !isReady)
-				return Promise.reject(new Error("Ballerina instance not initialized"));
+				return Promise.reject(
+					new Error("[balrun]: runtime instance is not initialized."),
+				);
 			return ballerinaRef.current.run(path, options);
 		},
 		[isReady],

--- a/packages/balrun/src/wasm-bridge.ts
+++ b/packages/balrun/src/wasm-bridge.ts
@@ -91,7 +91,7 @@ async function loadFromResponse(
 	const response = await source;
 	if (!response.ok) {
 		throw new Error(
-			`Failed to load WASM: ${response.status} ${response.statusText}`,
+			`[balrun]: failed to load WASM: ${response.status} ${response.statusText}`,
 		);
 	}
 

--- a/packages/balrun/tests/ballerina.test.ts
+++ b/packages/balrun/tests/ballerina.test.ts
@@ -84,10 +84,10 @@ describe("Ballerina", () => {
 		});
 
 		expect(ballerina.run("main.bal")).rejects.toThrow(
-			"Ballerina: Failed to initialize the WASM bridge:",
+			"[balrun]: failed to initialize the WASM bridge:",
 		);
 		expect(ballerina.run("main.bal")).rejects.toThrow(
-			"Ballerina: Failed to initialize the WASM bridge:",
+			"[balrun]: failed to initialize the WASM bridge:",
 		);
 	});
 });

--- a/packages/balrun/tests/wasm-bridge.test.ts
+++ b/packages/balrun/tests/wasm-bridge.test.ts
@@ -54,7 +54,7 @@ describe("WasmBridge", () => {
 				WasmBridge.load(
 					new Response("missing", { status: 404, statusText: "Not Found" }),
 				),
-			).rejects.toThrow("Failed to load WASM: 404 Not Found");
+			).rejects.toThrow("[balrun]: failed to load WASM: 404 Not Found");
 		});
 
 		it("throws on invalid URL", async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized error messages with consistent `[balrun]:` prefix formatting
  * Improved error handling for runtime initialization and WASM bridge operations
  * Enhanced error reporting when runtime instance is not properly initialized

<!-- end of auto-generated comment: release notes by coderabbit.ai -->