### PR TITLE
Add validation for empty run path and wasm source

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -12,7 +12,7 @@
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": true
+			"preset": "recommended"
 		}
 	},
 	"javascript": {

--- a/packages/balrun/src/ballerina.ts
+++ b/packages/balrun/src/ballerina.ts
@@ -88,6 +88,7 @@ export class Ballerina {
 		path: string,
 		options?: BallerinaRunOptions,
 	): Promise<BallerinaRunResult> {
+		if (path === "") throw new Error("[balrun]: run path must not be empty.");
 		const bridge = await this.bridge();
 		return bridge.run(await this.fs(), path, {
 			...this._defaults,

--- a/packages/balrun/src/wasm-bridge.ts
+++ b/packages/balrun/src/wasm-bridge.ts
@@ -37,6 +37,8 @@ export class WasmBridge implements BallerinaCore {
 		path: string,
 		options?: BallerinaRunOptions,
 	): Promise<BallerinaRunResult> {
+		if (path === "")
+			return Promise.reject(new Error("[balrun]: run path must not be empty."));
 		return this.exports
 			.run(proxy, path, options)
 			.finally(() => this.clearScheduledTimeouts());
@@ -59,6 +61,10 @@ function loadWasm(
 	importObject: WebAssembly.Imports,
 ): Promise<WebAssembly.Instance> {
 	if (typeof source === "string") {
+		if (source === "")
+			return Promise.reject(
+				new Error("[balrun]: WASM source must not be empty."),
+			);
 		if (shouldFetch(source)) return loadRemote(source, importObject);
 		else return loadLocal(source, importObject);
 	} else {

--- a/packages/balrun/tests/ballerina.test.ts
+++ b/packages/balrun/tests/ballerina.test.ts
@@ -77,6 +77,15 @@ describe("Ballerina", () => {
 		expect(core.calls).toHaveLength(1);
 	});
 
+	it("throws when run path is empty", async () => {
+		const { ballerina, core } = createBallerina();
+
+		expect(ballerina.run("")).rejects.toThrow(
+			"[balrun]: run path must not be empty.",
+		);
+		expect(core.calls).toHaveLength(0);
+	});
+
 	it("allows retrying initialization after a bridge load failure", async () => {
 		const ballerina = new Ballerina({
 			fs: new MemFS({ "main.bal": "" }),

--- a/packages/balrun/tests/wasm-bridge.test.ts
+++ b/packages/balrun/tests/wasm-bridge.test.ts
@@ -63,12 +63,24 @@ describe("WasmBridge", () => {
 			).rejects.toThrow();
 		});
 
+		it("throws when source is empty", async () => {
+			expect(WasmBridge.load("")).rejects.toThrow(
+				"[balrun]: WASM source must not be empty.",
+			);
+		});
+
 		it("throws on invalid local path", async () => {
 			expect(WasmBridge.load("/tmp/balrun-missing.wasm")).rejects.toThrow();
 		});
 	});
 
 	describe("run", () => {
+		it("throws when run path is empty", async () => {
+			expect(bridge.run(new MemFS({}), "")).rejects.toThrow(
+				"[balrun]: run path must not be empty.",
+			);
+		});
+
 		it("runs a Ballerina file and returns the result", async () => {
 			const fs = new MemFS({
 				"main.bal": await Bun.file(


### PR DESCRIPTION
Depends on #35


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent execution with empty run paths and WASM sources, providing informative error messages when invalid inputs are supplied.

* **Configuration**
  * Updated Biome linter configuration syntax.

* **Tests**
  * Expanded test coverage for error handling and validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->