### PR TITLE
Update Ballerina interpreter submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "packages/ballerina-wasm/ballerina-lang-go"]
-	path = packages/ballerina-wasm/ballerina-lang-go
-	url = https://github.com/ballerina-platform/ballerina-lang-go
 [submodule "packages/ballerina-wasm/ballerina"]
 	path = packages/ballerina-wasm/ballerina
 	url = https://github.com/ballerina-nutcracker/ballerina

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "packages/ballerina-wasm/ballerina-lang-go"]
 	path = packages/ballerina-wasm/ballerina-lang-go
 	url = https://github.com/ballerina-platform/ballerina-lang-go
+[submodule "packages/ballerina-wasm/ballerina"]
+	path = packages/ballerina-wasm/ballerina
+	url = https://github.com/ballerina-nutcracker/ballerina

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-[`@snelusha/balrun`](https://github.com/snelusha/balrun) runs Ballerina from JavaScript/TypeScript by loading `ballerina.wasm`, which is built from the [`ballerina-lang-go`](https://github.com/ballerina-platform/ballerina-lang-go) submodule.
+[`@snelusha/balrun`](https://github.com/snelusha/balrun) runs Ballerina from JavaScript/TypeScript by loading `ballerina.wasm`, which is built from the [`ballerina`](https://github.com/ballerina-nutcracker/ballerina) submodule.
 
 ## Repository structure
 
@@ -13,7 +13,7 @@ Workspaces are declared in the root `package.json` as `apps/*`, `examples/*`, an
 | `examples/memfs`            | `example-memfs`     | In-memory filesystem usage example.       |
 | `examples/vite`             | `example-vite`      | Vite + React browser usage example.       |
 
-`packages/ballerina-wasm/ballerina-lang-go` is an upstream submodule and has its own `AGENTS.md`.
+`packages/ballerina-wasm/ballerina` is an upstream submodule and has its own `AGENTS.md`.
 
 ## Commands
 

--- a/packages/ballerina-wasm/biome.json
+++ b/packages/ballerina-wasm/biome.json
@@ -2,12 +2,6 @@
 	"root": false,
 	"extends": "//",
 	"files": {
-		"includes": [
-			"**",
-			"!**/*.go",
-			"!**/*.mod",
-			"!**/*.sum",
-			"!!ballerina-lang-go"
-		]
+		"includes": ["**", "!**/*.go", "!**/*.mod", "!**/*.sum", "!!ballerina"]
 	}
 }

--- a/packages/ballerina-wasm/go.mod
+++ b/packages/ballerina-wasm/go.mod
@@ -2,7 +2,7 @@ module ballerina-wasm
 
 go 1.26
 
-replace ballerina-lang-go => ./ballerina-lang-go/
+replace ballerina-lang-go => ./ballerina/
 
 require ballerina-lang-go v0.0.0-00010101000000-000000000000
 

--- a/packages/ballerina-wasm/turbo.json
+++ b/packages/ballerina-wasm/turbo.json
@@ -7,7 +7,7 @@
 				"**/*.go",
 				"go.mod",
 				"go.sum",
-				"../../.git/modules/packages/ballerina-wasm/ballerina-lang-go/HEAD"
+				"../../.git/modules/packages/ballerina-wasm/ballerina/HEAD"
 			],
 			"outputs": ["dist/**"]
 		}

--- a/packages/balrun/README.md
+++ b/packages/balrun/README.md
@@ -134,4 +134,4 @@ Vite handles this automatically: it detects the default WASM URL and emits `ball
 
 ## Acknowledgements
 
-Built on [ballerina-lang-go](https://github.com/ballerina-platform/ballerina-lang-go).
+Built on [ballerina](https://github.com/ballerina-nutcracker/ballerina).


### PR DESCRIPTION
Go module references remain `ballerina-lang-go` because the new upstream repo still declares `module ballerina-lang-go` in its `go.mod`. Renaming those locally breaks Go package resolution.

Resolves #43 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the WebAssembly build process to use the latest upstream Ballerina source.
  * Improved build tracking and configuration for the updated source layout.

* **Documentation**
  * Updated project guidance to reflect the current Ballerina source.
  * Refreshed the README attribution for the upstream repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->