### PR TITLE
Add support for runtime stop

### DIFF
--- a/packages/ballerina-wasm/main_wasm.go
+++ b/packages/ballerina-wasm/main_wasm.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	_ "ballerina-lang-go/lib/rt"
+	"ballerina-lang-go/platform/pal"
 	"ballerina-lang-go/projects"
 	"ballerina-lang-go/runtime"
 	"ballerina-lang-go/tools/diagnostics"
@@ -13,7 +14,23 @@ import (
 
 func main() {
 	js.Global().Set("run", js.FuncOf(run))
+	js.Global().Set("stop", js.FuncOf(stop))
 	select {}
+}
+
+func stop(_ js.Value, args []js.Value) any {
+	if len(args) != 1 || args[0].Type() != js.TypeString {
+		return false
+	}
+
+	switch args[0].String() {
+	case "graceful":
+		return activeRunContext.sendSignal(pal.GracefulStop)
+	case "immediate":
+		return activeRunContext.sendSignal(pal.ImmediateStop)
+	default:
+		return false
+	}
 }
 
 type runOptions struct {
@@ -37,14 +54,6 @@ func parseRunOptions(opts js.Value) runOptions {
 
 func run(_ js.Value, args []js.Value) any {
 	return newPromise(func(resolve js.Value, _ js.Value) {
-		if len(args) < 2 {
-			resolve.Invoke(jsError(fmt.Errorf("expected at least 2 arguments: (fsProxy, path)")))
-			return
-		}
-
-		proxy := args[0]
-		path := args[1].String()
-
 		var optsArg js.Value
 		if len(args) >= 3 {
 			optsArg = args[2]
@@ -59,10 +68,28 @@ func run(_ js.Value, args []js.Value) any {
 			stderr = os.Stderr
 		}
 
+		if len(args) < 2 {
+			fmt.Fprintln(stderr, "error: expected at least 2 arguments: (fsProxy, path)")
+			resolve.Invoke(1)
+			return
+		}
+
+		proxy := args[0]
+		path := args[1].String()
+
+		signalSource, signals := newSignalSource()
+		if !activeRunContext.begin(signalSource) {
+			signalSource.cleanup()
+			fmt.Fprintln(stderr, "error: a Ballerina run is already in progress")
+			resolve.Invoke(1)
+			return
+		}
+		defer activeRunContext.end(signalSource)
+
 		defer func() {
 			if r := recover(); r != nil {
-				fmt.Fprintf(stderr, "%v\n", r)
-				resolve.Invoke(js.Null())
+				fmt.Fprintf(stderr, "error: %v\n", r)
+				resolve.Invoke(1)
 			}
 		}()
 
@@ -70,42 +97,49 @@ func run(_ js.Value, args []js.Value) any {
 
 		result, err := projects.Load(fsys, path)
 		if err != nil {
-			resolve.Invoke(jsError(err))
+			fmt.Fprintf(stderr, "error: %v\n", err)
+			resolve.Invoke(1)
 			return
 		}
 
 		if diags := result.Diagnostics(); diags.HasErrors() {
 			printDiagnostics(fsys, path, stderr, diags, diagnostics.NewDiagnosticEnv(), opts.noColors)
-			resolve.Invoke(js.Null())
+			resolve.Invoke(1)
 			return
 		}
 
 		compilation := result.Project().CurrentPackage().Compilation()
 		if diags := compilation.DiagnosticResult(); diags.HasErrors() {
 			printDiagnostics(fsys, path, stderr, diags, compilation.DiagnosticEnv(), opts.noColors)
-			resolve.Invoke(js.Null())
+			resolve.Invoke(1)
 			return
 		}
 
 		birPkgs := projects.NewBallerinaBackend(compilation).BIRPackages()
 		if len(birPkgs) == 0 {
-			resolve.Invoke(jsError(fmt.Errorf("BIR generation failed: no BIR package produced")))
+			fmt.Fprintln(stderr, "error: BIR generation failed: no BIR package produced")
+			resolve.Invoke(1)
 			return
 		}
 
-		pal := newPal(stdout, stderr)
+		pal := newPal(stdout, stderr, signals)
 		rt := runtime.NewRuntime(pal, result.Project().Environment().TypeEnv())
+		if !activeRunContext.setRuntime(signalSource, rt) {
+			fmt.Fprintln(stderr, "error: failed to register the Ballerina runtime")
+			resolve.Invoke(1)
+			return
+		}
+
 		for _, birPkg := range birPkgs {
-			if err := rt.Interpret(*birPkg); err != nil {
-				resolve.Invoke(jsError(err))
+			if err := rt.Init(*birPkg); err != nil {
+				fmt.Fprintf(stderr, "error: %v\n", err)
+				resolve.Invoke(1)
 				return
 			}
 		}
 
-		resolve.Invoke(js.Null())
+		rt.Listen()
+		exitCode := <-rt.ExitStatus
+		resolve.Invoke(int(exitCode))
 	})
-}
-
-func jsError(err error) map[string]any {
-	return map[string]any{"error": err.Error()}
 }

--- a/packages/ballerina-wasm/pal_wasm.go
+++ b/packages/ballerina-wasm/pal_wasm.go
@@ -170,7 +170,7 @@ func (c *fetchHTTPClient) extractBody(resp js.Value) ([]byte, error) {
 	return body, nil
 }
 
-func newPal(stdout, stderr io.Writer) pal.Platform {
+func newPal(stdout, stderr io.Writer, signals pal.SignalSource) pal.Platform {
 	return pal.Platform{
 		IO: pal.IO{
 			Stdout: stdout.Write,
@@ -181,5 +181,6 @@ func newPal(stdout, stderr io.Writer) pal.Platform {
 				return &fetchHTTPClient{cfg: cfg}
 			},
 		},
+		Signals: signals,
 	}
 }

--- a/packages/ballerina-wasm/run_context_wasm.go
+++ b/packages/ballerina-wasm/run_context_wasm.go
@@ -53,17 +53,5 @@ func (rc *runContext) sendSignal(sig pal.Signal) bool {
 	if rc.signals == nil {
 		return false
 	}
-	rc.signals.send(sig)
-	return true
+	return rc.signals.send(sig)
 }
-
-// func (rc *runContext) begin(signals *signalSource) bool {
-// 	rc.mu.Lock()
-// 	defer rc.mu.Unlock()
-//
-// 	rc.signals = signals
-// 	if rc.signals != nil || rc.rt != nil {
-// 		return false
-// 	}
-// 	return true
-// }

--- a/packages/ballerina-wasm/run_context_wasm.go
+++ b/packages/ballerina-wasm/run_context_wasm.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"ballerina-lang-go/platform/pal"
+	"ballerina-lang-go/runtime"
+	"sync"
+)
+
+type runContext struct {
+	mu sync.Mutex
+
+	rt      *runtime.Runtime
+	signals *signalSource
+}
+
+var activeRunContext = &runContext{}
+
+func (rc *runContext) begin(signals *signalSource) bool {
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+	if rc.signals != nil || rc.rt != nil {
+		return false
+	}
+	rc.signals = signals
+	return true
+}
+
+func (rc *runContext) end(signals *signalSource) bool {
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+	if rc.signals != signals {
+		return false
+	}
+	rc.rt = nil
+	rc.signals = nil
+	signals.cleanup()
+	return true
+}
+
+func (rc *runContext) setRuntime(signals *signalSource, rt *runtime.Runtime) bool {
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+	if rc.signals != signals {
+		return false
+	}
+	rc.rt = rt
+	return true
+}
+
+func (rc *runContext) sendSignal(sig pal.Signal) bool {
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+	if rc.signals == nil {
+		return false
+	}
+	rc.signals.send(sig)
+	return true
+}
+
+// func (rc *runContext) begin(signals *signalSource) bool {
+// 	rc.mu.Lock()
+// 	defer rc.mu.Unlock()
+//
+// 	rc.signals = signals
+// 	if rc.signals != nil || rc.rt != nil {
+// 		return false
+// 	}
+// 	return true
+// }

--- a/packages/ballerina-wasm/signals_wasm.go
+++ b/packages/ballerina-wasm/signals_wasm.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"ballerina-lang-go/platform/pal"
+	"sync"
+)
+
+type signalSource struct {
+	mu sync.Mutex
+	ch chan pal.Signal
+}
+
+func (s *signalSource) send(sig pal.Signal) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	select {
+	case s.ch <- sig:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *signalSource) cleanup() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	close(s.ch)
+}
+
+func newSignalSource() (*signalSource, pal.SignalSource) {
+	ch := make(chan pal.Signal, 2)
+	return &signalSource{ch: ch}, pal.SignalSource{
+		Signals: ch,
+	}
+}

--- a/packages/balrun/README.md
+++ b/packages/balrun/README.md
@@ -23,12 +23,23 @@ Accepts a `.bal` file, a package directory, or `.` for the current package.
 import { Ballerina } from "@snelusha/balrun";
 
 const ballerina = new Ballerina({ colors: false });
-
-// Returns null on success, or { error: "..." } on failure
-const result = await ballerina.run("./main.bal", { colors: true });
+const exitCode = await ballerina.run("./main.bal", { colors: true });
 ```
 
 Options passed to `run()` override the constructor defaults for that call only.
+
+## Stopping a run
+
+Use `stop()` to stop a running Ballerina program. The default mode is graceful; pass `"immediate"` to stop immediately.
+
+```ts
+const running = ballerina.run("./service.bal");
+
+await ballerina.stop();
+const exitCode = await running;
+```
+
+The CLI forwards `SIGINT` and `SIGTERM` as graceful stops, and `SIGQUIT` as an immediate stop.
 
 ## React
 

--- a/packages/balrun/bin/cli.mjs
+++ b/packages/balrun/bin/cli.mjs
@@ -9,11 +9,35 @@ if (!path) {
 	process.exit(1);
 }
 
-const result = await new Ballerina({
-	colors: Boolean(process.stderr.isTTY),
-}).run(path);
+const keepAlive = setInterval(() => {}, 1_000);
 
-if (result) {
-	process.stderr.write(`error: ${result.error}\n`);
-	process.exit(1);
+const ballerina = new Ballerina({
+	colors: Boolean(process.stderr.isTTY),
+	stderr: process.stderr,
+});
+const signalHandlers = [
+	["SIGINT", "graceful"],
+	["SIGTERM", "graceful"],
+	["SIGQUIT", "immediate"],
+].map(([name, mode]) => {
+	const handler = () => void ballerina.stop(mode);
+	process.on(name, handler);
+	return [name, handler];
+});
+
+let exitCode;
+try {
+	exitCode = await ballerina.run(path);
+} finally {
+	clearInterval(keepAlive);
+	for (const [name, handler] of signalHandlers) process.off(name, handler);
+}
+
+await Promise.all([flush(process.stdout), flush(process.stderr)]);
+process.exit(exitCode);
+
+function flush(stream) {
+	return new Promise((resolve, reject) => {
+		stream.write("", (err) => (err ? reject(err) : resolve()));
+	});
 }

--- a/packages/balrun/bin/cli.mjs
+++ b/packages/balrun/bin/cli.mjs
@@ -28,16 +28,12 @@ const signalHandlers = [
 let exitCode;
 try {
 	exitCode = await ballerina.run(path);
+} catch (error) {
+	process.stderr.write(`${error}\n`);
+	exitCode = 1;
 } finally {
 	clearInterval(keepAlive);
 	for (const [name, handler] of signalHandlers) process.off(name, handler);
 }
 
-await Promise.all([flush(process.stdout), flush(process.stderr)]);
-process.exit(exitCode);
-
-function flush(stream) {
-	return new Promise((resolve, reject) => {
-		stream.write("", (err) => (err ? reject(err) : resolve()));
-	});
-}
+process.exitCode = exitCode;

--- a/packages/balrun/src/ballerina-core.ts
+++ b/packages/balrun/src/ballerina-core.ts
@@ -11,8 +11,10 @@ export interface BallerinaRunOptions {
 	stderr?: StreamWriter;
 }
 
-export type BallerinaRunResult = { error?: string } | null;
+export type BallerinaRunResult = number;
+export type BallerinaStopMode = "graceful" | "immediate";
 
 export interface BallerinaCore {
 	run(proxy: FS, path: string, options?: BallerinaRunOptions): Promise<BallerinaRunResult>;
+	stop?(mode: BallerinaStopMode): boolean;
 }

--- a/packages/balrun/src/ballerina.ts
+++ b/packages/balrun/src/ballerina.ts
@@ -1,7 +1,12 @@
 import { NodeFS } from "./fs/node";
 
 import type { FS } from "./fs/core";
-import type { BallerinaCore, BallerinaRunOptions, BallerinaRunResult } from "./ballerina-core";
+import type {
+	BallerinaCore,
+	BallerinaRunOptions,
+	BallerinaRunResult,
+	BallerinaStopMode,
+} from "./ballerina-core";
 
 const DEFAULT_WASM_PATH = new URL("./ballerina.wasm", import.meta.url).href;
 
@@ -85,6 +90,10 @@ export class Ballerina {
 			...this._defaults,
 			...options,
 		});
+	}
+
+	async stop(mode: BallerinaStopMode = "graceful"): Promise<boolean> {
+		return (await this.bridge()).stop?.(mode) ?? false;
 	}
 }
 

--- a/packages/balrun/src/index.ts
+++ b/packages/balrun/src/index.ts
@@ -7,5 +7,6 @@ export type {
 	BallerinaCore,
 	BallerinaRunOptions,
 	BallerinaRunResult,
+	BallerinaStopMode,
 	StreamWriter,
 } from "./ballerina-core";

--- a/packages/balrun/src/wasm-bridge.ts
+++ b/packages/balrun/src/wasm-bridge.ts
@@ -1,10 +1,16 @@
-import type { BallerinaCore, BallerinaRunOptions, BallerinaRunResult } from "./ballerina-core";
+import type {
+	BallerinaCore,
+	BallerinaRunOptions,
+	BallerinaRunResult,
+	BallerinaStopMode,
+} from "./ballerina-core";
 import type { FS } from "./fs/core";
 
 const NODE_FS_PROMISES_MODULE = "node:fs/promises";
 
 export interface WasmExports {
 	run: BallerinaCore["run"];
+	stop: (mode: BallerinaStopMode) => boolean;
 }
 
 type GoRuntime = Go & {
@@ -29,6 +35,10 @@ export class WasmBridge implements BallerinaCore {
 	run(proxy: FS, path: string, options?: BallerinaRunOptions): Promise<BallerinaRunResult> {
 		if (path === "") return Promise.reject(new Error("[balrun]: run path must not be empty."));
 		return this.exports.run(proxy, path, options).finally(() => this.clearScheduledTimeouts());
+	}
+
+	stop(mode: BallerinaStopMode): boolean {
+		return this.exports.stop(mode);
 	}
 
 	private clearScheduledTimeouts(): void {

--- a/packages/balrun/src/wasm.d.ts
+++ b/packages/balrun/src/wasm.d.ts
@@ -1,5 +1,5 @@
 import type { FS } from "./fs/core";
-import type { BallerinaRunOptions } from "./ballerina-core";
+import type { BallerinaRunOptions, BallerinaStopMode } from "./ballerina-core";
 
 declare global {
 	class Go {
@@ -7,9 +7,6 @@ declare global {
 		run(instance: WebAssembly.Instance): Promise<void>;
 	}
 
-	var run: (
-		proxy: FS,
-		path: string,
-		options?: BallerinaRunOptions,
-	) => Promise<{ error?: string } | null>;
+	var run: (proxy: FS, path: string, options?: BallerinaRunOptions) => Promise<number>;
+	var stop: (mode: BallerinaStopMode) => boolean;
 }

--- a/packages/balrun/tests/ballerina.test.ts
+++ b/packages/balrun/tests/ballerina.test.ts
@@ -3,16 +3,26 @@ import { describe, expect, it } from "bun:test";
 import { Ballerina } from "../src/ballerina.ts";
 import { MemFS } from "./memfs";
 
-import type { BallerinaCore, BallerinaRunOptions } from "../src/ballerina-core.ts";
+import type {
+	BallerinaCore,
+	BallerinaRunOptions,
+	BallerinaStopMode,
+} from "../src/ballerina-core.ts";
 import type { BallerinaOptions } from "../src/ballerina.ts";
 import type { FS } from "../src/fs/core.ts";
 
 class SpyCore implements BallerinaCore {
 	calls: Array<{ fs: FS; path: string; options?: BallerinaRunOptions }> = [];
+	signals: string[] = [];
 
 	async run(fs: FS, path: string, options?: BallerinaRunOptions) {
 		this.calls.push({ fs, path, options });
-		return null;
+		return 0;
+	}
+
+	stop(mode: BallerinaStopMode) {
+		this.signals.push(mode);
+		return true;
 	}
 }
 
@@ -63,6 +73,14 @@ describe("Ballerina", () => {
 			stdout: stdout,
 			stderr: undefined,
 		});
+	});
+
+	it("sends graceful and immediate stop signals", async () => {
+		const { ballerina, core } = createBallerina();
+
+		expect(await ballerina.stop()).toBe(true);
+		expect(await ballerina.stop("immediate")).toBe(true);
+		expect(core.signals).toEqual(["graceful", "immediate"]);
 	});
 
 	it("initializes with provided core and fs", async () => {

--- a/packages/balrun/tests/cli.test.ts
+++ b/packages/balrun/tests/cli.test.ts
@@ -3,19 +3,56 @@ import { fileURLToPath } from "node:url";
 
 const CLI_PATH = fileURLToPath(new URL("../bin/cli.mjs", import.meta.url));
 
-async function runCli(args: string[]) {
+async function runCli(args: string[], signal?: NodeJS.Signals) {
 	const proc = Bun.spawn([process.execPath, CLI_PATH, ...args], {
 		stderr: "pipe",
 		stdout: "pipe",
 	});
 
-	const [exitCode, stdout, stderr] = await Promise.all([
-		proc.exited,
-		new Response(proc.stdout).text(),
-		new Response(proc.stderr).text(),
-	]);
+	if (!signal) {
+		const [exitCode, stdout, stderr] = await Promise.all([
+			proc.exited,
+			new Response(proc.stdout).text(),
+			new Response(proc.stderr).text(),
+		]);
+		return { exitCode, stdout, stderr };
+	}
 
-	return { exitCode, stdout, stderr };
+	const reader = proc.stdout.getReader();
+	const decoder = new TextDecoder();
+	let stdout = "";
+	let ready: (() => void) | undefined;
+	const readyPromise = new Promise<void>((resolve) => {
+		ready = resolve;
+	});
+	const stdoutPromise = (async () => {
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) return stdout;
+			stdout += decoder.decode(value, { stream: true });
+			if (stdout.includes("ready\n")) ready?.();
+		}
+	})();
+
+	try {
+		await Promise.race([
+			readyPromise,
+			new Promise((_, reject) => setTimeout(() => reject(new Error("timed out")), 10_000)),
+		]);
+		proc.kill(signal);
+		const [exitCode, completedStdout, stderr] = await Promise.all([
+			proc.exited,
+			stdoutPromise,
+			new Response(proc.stderr).text(),
+		]);
+		return { exitCode, stdout: completedStdout, stderr };
+	} finally {
+		proc.kill();
+	}
+}
+
+function fixturePath(name: string): string {
+	return fileURLToPath(new URL(`./fixtures/${name}`, import.meta.url));
 }
 
 describe("CLI", () => {
@@ -41,5 +78,21 @@ describe("CLI", () => {
 		expect(result.exitCode).toBe(1);
 		expect(result.stderr).toContain("error:");
 		expect(result.stderr).toContain("file does not exist");
+	});
+
+	it("forwards SIGINT as a graceful stop", async () => {
+		const result = await runCli([fixturePath("listener.bal")], "SIGINT");
+
+		expect(result.exitCode).toBe(130);
+		expect(result.stdout).toContain("graceful stop");
+		expect(result.stderr).toBe("");
+	});
+
+	it("forwards SIGQUIT as an immediate stop", async () => {
+		const result = await runCli([fixturePath("listener.bal")], "SIGQUIT");
+
+		expect(result.exitCode).toBe(131);
+		expect(result.stdout).toContain("immediate stop");
+		expect(result.stderr).toBe("");
 	});
 });

--- a/packages/balrun/tests/cli.test.ts
+++ b/packages/balrun/tests/cli.test.ts
@@ -34,10 +34,13 @@ async function runCli(args: string[], signal?: NodeJS.Signals) {
 		}
 	})();
 
+	let timeout: ReturnType<typeof setTimeout> | undefined;
 	try {
 		await Promise.race([
 			readyPromise,
-			new Promise((_, reject) => setTimeout(() => reject(new Error("timed out")), 10_000)),
+			new Promise((_, reject) => {
+				timeout = setTimeout(() => reject(new Error("timed out")), 10_000);
+			}),
 		]);
 		proc.kill(signal);
 		const [exitCode, completedStdout, stderr] = await Promise.all([
@@ -47,6 +50,7 @@ async function runCli(args: string[], signal?: NodeJS.Signals) {
 		]);
 		return { exitCode, stdout: completedStdout, stderr };
 	} finally {
+		if (timeout) clearTimeout(timeout);
 		proc.kill();
 	}
 }

--- a/packages/balrun/tests/fixtures/listener.bal
+++ b/packages/balrun/tests/fixtures/listener.bal
@@ -1,0 +1,29 @@
+import ballerina/io;
+
+class TestListener {
+    public function attach(service object {} svc, () attachPoint = ()) returns () {
+        _ = svc;
+        _ = attachPoint;
+        io:println("ready");
+    }
+
+    public function detach(service object {} svc) returns error? {
+        _ = svc;
+    }
+
+    public function 'start() returns error? {
+    }
+
+    public function gracefulStop() returns error? {
+        io:println("graceful stop");
+    }
+
+    public function immediateStop() returns error? {
+        io:println("immediate stop");
+    }
+}
+
+listener TestListener testListener = new ();
+
+service on testListener {
+}

--- a/packages/balrun/tests/react.test.ts
+++ b/packages/balrun/tests/react.test.ts
@@ -57,7 +57,7 @@ describe("React", () => {
 
 		expect(container.innerHTML).toBe("<output>true:null</output>");
 		expect(runtime.current).not.toBeNull();
-		expect(runtime.current!.run("main.bal")).resolves.toBeNull();
+		expect(runtime.current!.run("main.bal")).resolves.toBe(0);
 		expect(stdout.join("")).toBe("Hello, Ballerina!\n");
 
 		await act(async () => root.unmount());

--- a/packages/balrun/tests/wasm-bridge.test.ts
+++ b/packages/balrun/tests/wasm-bridge.test.ts
@@ -75,7 +75,7 @@ describe("WasmBridge", () => {
 			);
 		});
 
-		it("runs a Ballerina file and returns the result", async () => {
+		it("runs a Ballerina file and returns its exit code", async () => {
 			const fs = new MemFS({
 				"main.bal": await Bun.file(new URL("./fixtures/hello.bal", import.meta.url)).text(),
 			});
@@ -83,8 +83,18 @@ describe("WasmBridge", () => {
 			const result = await bridge.run(fs, "main.bal", {
 				stdout: { write: (chunk) => stdout.push(chunk) },
 			});
-			expect(result).toBeNull();
+			expect(result).toBe(0);
 			expect(stdout.join("")).toBe("Hello, Ballerina!\n");
+		});
+
+		it("returns a non-zero exit code when loading fails", async () => {
+			const stderr: string[] = [];
+			const exitCode = await bridge.run(new MemFS({}), "missing.bal", {
+				stderr: { write: (chunk) => stderr.push(chunk) },
+			});
+
+			expect(exitCode).toBe(1);
+			expect(stderr.join("")).toBe("error: open missing.bal: file does not exist\n");
 		});
 	});
 });


### PR DESCRIPTION
Resolves #39

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added graceful and immediate stopping for running Ballerina programs.
  - `run()` now returns a numeric exit code.
  - CLI signals support graceful and immediate shutdown modes.
  - Improved runtime error reporting through stderr and exit statuses.
  - Prevented overlapping program runs and improved runtime cleanup.

- **Documentation**
  - Updated usage examples and signal-handling guidance.

- **Tests**
  - Added coverage for stop modes, signal handling, exit codes, and missing files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->