### PR TITLE
Fix duplicate error prefix on runtime errors

### DIFF
--- a/packages/ballerina-wasm/main_wasm.go
+++ b/packages/ballerina-wasm/main_wasm.go
@@ -162,7 +162,7 @@ func run(_ js.Value, args []js.Value) any {
 
 		for _, birPkg := range birPkgs {
 			if err := rt.Init(*birPkg); err != nil {
-				fmt.Fprintf(stderr, "error: %v\n", err)
+				fmt.Fprintln(stderr, err)
 				resolve.Invoke(1)
 				return
 			}


### PR DESCRIPTION
Resolves #59


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Runtime initialization errors are now displayed directly in standard error output without the redundant “error:” prefix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->